### PR TITLE
fix: declare import_transactions tags as a set, not a string

### DIFF
--- a/src/ghostfolio_mcp/ghostfolio_tools.py
+++ b/src/ghostfolio_mcp/ghostfolio_tools.py
@@ -193,7 +193,7 @@ def register_tools(mcp: FastMCP, config: GhostfolioConfig) -> None:
     # =============================================================================
 
     @mcp.tool(
-        tags=("import"),
+        tags={"import"},
         annotations={
             "readOnlyHint": False,
             "destructiveHint": False,


### PR DESCRIPTION
## Problem

`tags=("import")` on line 196 of `src/ghostfolio_mcp/ghostfolio_tools.py` is a parenthesised string, not a one-element tuple — Python only treats `("x",)` (with trailing comma) as a tuple. Without the comma, the parens are just grouping, so `tags=("import")` evaluates to the string `"import"`.

## Effect

Tag-membership checks iterate `tags`, so they iterate the *string* `"import"`, yielding the characters `"i"`, `"m"`, `"p"`, `"o"`, `"r"`, `"t"` — never the intended single tag `"import"`. As a result, any feature gated by tag membership against `import_transactions` silently misbehaves. In a downstream deployment we use `GHOSTFOLIO_DISABLED_TAGS=import` to disable this tool, and that filter never matched the tool because of this typo.

## Fix

One-line change: use a set literal `tags={"import"}`, matching the style of every other `@mcp.tool` declaration in the same file (every other tool uses `tags={"..."}`).

```diff
 @mcp.tool(
-    tags=("import"),
+    tags={"import"},
     annotations={
         "readOnlyHint": False,
         "destructiveHint": False,
         "idempotentHint": False,
     },
 )
```

No tests are added — no test caught this because tag iteration is a runtime path, and a plain typo fix doesn't typically warrant new test scaffolding. Happy to add one if you'd prefer.