### PR TITLE
fix(client): trailing slash by HTTP method; tolerate empty response bodies

### DIFF
--- a/src/ghostfolio_mcp/ghostfolio_client.py
+++ b/src/ghostfolio_mcp/ghostfolio_client.py
@@ -98,18 +98,32 @@ class GhostfolioClient:
 
         await self._refresh_jwt_token()
 
-        # Build URL path
+        # Build URL path. Ghostfolio's NestJS routes are inconsistent on the
+        # trailing slash: most GET endpoints (asset, portfolio, account, etc.)
+        # require the trailing slash, while several POST/PATCH/DELETE
+        # endpoints — notably /market-data/MANUAL/<symbol>, /admin/profile-data
+        # /MANUAL/<symbol>, and /order/<id> — return 404 *with* the trailing
+        # slash. Match the slash to the method.
         url_path = f"/{api_version}/{path.lstrip('/')}"
         if object_id:
             url_path = f"{url_path.rstrip('/')}/{object_id}"
-        if not url_path.endswith("/"):
-            url_path += "/"
+        if method.upper() == "GET":
+            if not url_path.endswith("/"):
+                url_path += "/"
+        else:
+            url_path = url_path.rstrip("/")
 
         headers = {"Authorization": f"Bearer {self._jwt_token}"}
         resp = await self.client.request(
             method, url_path, params=params, json=data, headers=headers
         )
         resp.raise_for_status()
+        # Some Ghostfolio admin endpoints (e.g. PATCH
+        # /admin/profile-data/MANUAL/<symbol>) return 200 with an empty body.
+        # resp.json() raises JSONDecodeError on empty content; treat empty as
+        # an empty dict.
+        if not resp.content:
+            return {}
         return resp.json()
 
     async def get(


### PR DESCRIPTION
## Two related bugs surfaced when writing against a live Ghostfolio (3.x)

### 1. Trailing-slash mismatch by HTTP method

`GhostfolioClient.request()` unconditionally appends a trailing slash:

```python
if not url_path.endswith(\"/\"):
    url_path += \"/\"
```

Ghostfolio's NestJS routes are inconsistent here:

- **GET** endpoints (\`/asset/...\`, \`/portfolio/...\`, \`/account/...\`, etc.) return **404 _without_ a trailing slash**
- **POST / PATCH / DELETE** on at least these endpoints return **404 _with_ a trailing slash**:
  - \`/market-data/MANUAL/<symbol>\`
  - \`/admin/profile-data/MANUAL/<symbol>\`
  - \`/order/<id>\`

So the current code makes GETs work but every write I tried 404'd until I removed the slash. Fix: match the slash to the method — append for GET, strip for everything else.

### 2. \`resp.json()\` on empty body

\`PATCH /admin/profile-data/MANUAL/<symbol>\` returns \`200 OK\` with an **empty** response body. \`resp.json()\` then raises:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Fix: treat empty \`resp.content\` as \`{}\`.

## Reproducer (Ghostfolio 3.0+)

```python
async with get_ghostfolio_client(config) as client:
    # 404 with current main, succeeds on this PR
    await client.post(
        \"market-data/MANUAL/EXAMPLE\",
        data={\"marketData\": [{\"date\": \"2026-05-08\", \"marketPrice\": 100}]},
    )
```

## Diff

```diff
- if not url_path.endswith(\"/\"):
-     url_path += \"/\"
+ if method.upper() == \"GET\":
+     if not url_path.endswith(\"/\"):
+         url_path += \"/\"
+ else:
+     url_path = url_path.rstrip(\"/\")
  ...
  resp.raise_for_status()
+ if not resp.content:
+     return {}
  return resp.json()
```

## Tests

No tests added. The existing suite mocks at the httpx level so it doesn't surface the NestJS route strictness or empty-body cases. Happy to add integration-style coverage if you'd prefer that.

Came out of a downstream effort that needed the write endpoints — encountered both bugs in production. Splitting this into a single tight PR; happy to break it into two if you'd rather review them separately.