### PR TITLE
feat(tools): add add_market_data_points

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Sentry is completely optional. If you don't set `SENTRY_DSN`, the server will ru
 ### Market Data & Symbol Tools
 
 - `get_market_data_for_asset`: Get market data for a specific asset
+- `add_market_data_points`: Add one or more market data points for an asset (typically a `MANUAL` data source — Ghostfolio rejects writes for auto-fetched sources)
 - `get_symbol_data`: Get symbol data for a specific asset from a data source
 - `get_historical_data`: Get historical data for a specific symbol on a specific date
 - `lookup_symbols`: Search for symbols using a query string

--- a/src/ghostfolio_mcp/ghostfolio_tools.py
+++ b/src/ghostfolio_mcp/ghostfolio_tools.py
@@ -293,6 +293,55 @@ def register_tools(mcp: FastMCP, config: GhostfolioConfig) -> None:
         async with get_ghostfolio_client(config) as client:
             return await client.get(f"market-data/{data_source}/{symbol}")
 
+    @mcp.tool(
+        tags={"market-data", "create"},
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def add_market_data_points(
+        data_source: Annotated[
+            str,
+            Field(
+                description="Data source for the symbol. Typically 'MANUAL' — Ghostfolio rejects market-data writes for auto-fetched sources like 'YAHOO' or 'COINGECKO'"
+            ),
+        ],
+        symbol: Annotated[
+            str,
+            Field(
+                description="Symbol/ticker of the asset (e.g., 'TRUE-UNLISTED', 'PILLAR3A-FINPENSION-X')"
+            ),
+        ],
+        market_data: Annotated[
+            list[dict[str, Any]],
+            Field(
+                description="List of market data points. Each entry must include 'date' (ISO 8601, e.g. '2026-04-30T00:00:00.000Z') and 'marketPrice' (numeric value of the asset at that date)"
+            ),
+        ],
+    ) -> dict[str, Any]:
+        """
+        Add one or more market data points for a specific asset.
+
+        Posts to the market-data endpoint for the given data source and
+        symbol. Same (symbol, date) overwrites the existing point; passing
+        the same input twice yields the same end state.
+
+        Args:
+            data_source: Data source (typically 'MANUAL')
+            symbol: Symbol/ticker of the asset
+            market_data: List of {date, marketPrice} entries
+
+        Returns:
+            Dictionary containing the upstream response
+        """
+        async with get_ghostfolio_client(config) as client:
+            return await client.post(
+                f"market-data/{data_source}/{symbol}",
+                data={"marketData": market_data},
+            )
+
     # =============================================================================
     # ORDER / ACTIVITY ENDPOINTS
     # =============================================================================


### PR DESCRIPTION
## Summary

Adds a write counterpart to `get_market_data_for_asset`: POSTs a list of `{date, marketPrice}` entries to `market-data/{data_source}/{symbol}`. Same `(symbol, date)` overwrites the existing point, so calling with the same input twice yields the same end state.

## Motivation

Some assets in a Ghostfolio portfolio cannot be auto-priced — manually-tracked robo-advisor accounts, pension contracts, unlisted holdings, custom cash buckets. Today, updating their NAV requires opening the Ghostfolio admin UI for each one. With this tool, an MCP client can update those values programmatically, which is the natural complement to the read-side coverage already in place.

Ghostfolio's API rejects market-data writes against auto-fetched sources like `YAHOO` or `COINGECKO`, so this tool will return an error if used against those — `MANUAL` is the typical (and effectively only) use case.

## Behaviour

- POST `/api/v1/market-data/{data_source}/{symbol}` with body `{"marketData": [...]}`
- `market_data` parameter takes a list, so callers can batch multiple points in one call
- Returns whatever Ghostfolio returns (usually a minimal success object)

## Annotations

- `readOnlyHint`: false (writes data)
- `destructiveHint`: false (additive — same `(symbol, date)` overwrites, doesn't destroy other points)
- `idempotentHint`: true (same input → same end state)

## Tests

No new unit tests added — the tool is a thin wrapper over the client and the existing test suite covers only `parse_bool`. Happy to add tests in the style of `tests/test_utils.py` if you'd like a pattern set up; otherwise smoke-tested locally against Ghostfolio v3.2.0.

## Style

Matches existing tool style (docstring shape, tag/annotation pattern, parameter `Field` descriptions). README updated with one bullet under "Market Data & Symbol Tools".