### PR TITLE
feat(tools): add upsert_asset_profile (+ PATCH on client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Sentry is completely optional. If you don't set `SENTRY_DSN`, the server will ru
 - `get_historical_data`: Get historical data for a specific symbol on a specific date
 - `lookup_symbols`: Search for symbols using a query string
 - `get_asset_profile`: Get asset profile information for a specific symbol
+- `upsert_asset_profile`: Create-or-update an asset profile (idempotent; tolerates Ghostfolio's HTTP 500 on the create step and relies on the subsequent PATCH as the source of truth)
 
 ### Data Import Tools
 

--- a/src/ghostfolio_mcp/ghostfolio_client.py
+++ b/src/ghostfolio_mcp/ghostfolio_client.py
@@ -168,6 +168,18 @@ class GhostfolioClient:
             "PUT", path, data=data, api_version=api_version, object_id=object_id
         )
 
+    async def patch(
+        self,
+        path: str,
+        data: dict[str, Any] | None = None,
+        api_version: str = "v1",
+        object_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Perform a PATCH request to a Ghostfolio API path."""
+        return await self.request(
+            "PATCH", path, data=data, api_version=api_version, object_id=object_id
+        )
+
     async def delete(
         self, path: str, params: dict[str, Any] | None = None, api_version: str = "v1"
     ) -> dict[str, Any]:

--- a/src/ghostfolio_mcp/ghostfolio_tools.py
+++ b/src/ghostfolio_mcp/ghostfolio_tools.py
@@ -6,6 +6,7 @@ import logging
 from typing import Annotated
 from typing import Any
 
+import httpx
 from fastmcp import FastMCP
 from pydantic import Field
 
@@ -216,6 +217,96 @@ def register_tools(mcp: FastMCP, config: GhostfolioConfig) -> None:
         """
         async with get_ghostfolio_client(config) as client:
             return await client.get(f"asset/{data_source}/{symbol}")
+
+    @mcp.tool(
+        tags={"asset", "profile", "update"},
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        },
+    )
+    async def upsert_asset_profile(
+        data_source: Annotated[
+            str,
+            Field(
+                description="Data source for the symbol. Typically 'MANUAL' — Ghostfolio rejects profile-data writes for auto-fetched sources"
+            ),
+        ],
+        symbol: Annotated[
+            str,
+            Field(
+                description="Symbol/ticker of the asset. Permanent — renaming orphans associated activities and market data"
+            ),
+        ],
+        name: Annotated[
+            str,
+            Field(description="Human-readable name for the asset"),
+        ],
+        currency: Annotated[
+            str,
+            Field(description="Currency code of the asset (e.g., 'USD', 'CHF', 'EUR')"),
+        ],
+        asset_class: Annotated[
+            str,
+            Field(
+                description="Asset class: 'EQUITY', 'FIXED_INCOME', 'REAL_ESTATE', 'COMMODITY', 'LIQUIDITY' (cash), or 'ALTERNATIVE_INVESTMENT'. Note: Ghostfolio's enum does not include 'CASH' — use 'LIQUIDITY'"
+            ),
+        ],
+        asset_sub_class: Annotated[
+            str,
+            Field(
+                default="",
+                description="Optional asset sub-class (e.g., 'MUTUALFUND', 'CASH', 'ETF')",
+            ),
+        ] = "",
+    ) -> dict[str, Any]:
+        """
+        Create-or-update an asset profile.
+
+        POSTs an empty profile-data record (idempotent — Ghostfolio returns
+        HTTP 500 on both duplicate-create and some first-time-create paths
+        while still persisting the record, so this tolerates 500). Then
+        PATCHes metadata (name, currency, asset class, optional sub-class).
+        PATCH is the source of truth — if the profile doesn't exist after
+        the POST, PATCH will surface a 404. Calling twice with the same
+        input yields the same end state.
+
+        Args:
+            data_source: Data source (typically 'MANUAL')
+            symbol: Symbol/ticker of the asset
+            name: Human-readable name
+            currency: Currency code
+            asset_class: One of the Ghostfolio enum values
+            asset_sub_class: Optional sub-class
+
+        Returns:
+            Dictionary containing the final profile state from the PATCH response
+        """
+        async with get_ghostfolio_client(config) as client:
+            # POST admin/profile-data/{source}/{symbol} creates the record but
+            # Ghostfolio responds with HTTP 500 on both the duplicate-create
+            # path and (observed against v3.2.0) some first-time-create paths,
+            # while still persisting the record. Tolerate 500 here and treat
+            # the subsequent PATCH as the source of truth — PATCH will 404
+            # loudly if the profile genuinely does not exist.
+            try:
+                await client.post(f"admin/profile-data/{data_source}/{symbol}", data={})
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code != 500:
+                    raise
+
+            patch_payload: dict[str, Any] = {
+                "name": name,
+                "currency": currency,
+                "assetClass": asset_class,
+            }
+            if asset_sub_class:
+                patch_payload["assetSubClass"] = asset_sub_class
+
+            return await client.patch(
+                f"admin/profile-data/{data_source}/{symbol}", data=patch_payload
+            )
 
     # =============================================================================
     # IMPORT ENDPOINTS


### PR DESCRIPTION
## Summary

Adds an idempotent create-or-update tool for asset profiles. POSTs an empty profile-data record, then PATCHes metadata (`name`, `currency`, `assetClass`, optional `assetSubClass`) in a single call. Useful when an MCP client wants to reach a known-good profile state without managing existence first.

Also adds a `PATCH` method to `GhostfolioClient`. The existing client exposes `get/post/put/delete` but no PATCH; this is the first tool that needs it.

## Motivation

Same use case as `add_market_data_points` (PR #30): manually-tracked assets — pensions, robo-advisor accounts, unlisted holdings — need a registered profile before activities or NAVs can be recorded against them. Doing this conversationally from an MCP client today requires multiple calls and manual error handling for "already exists." An upsert-shaped tool lets the caller pass a desired-state metadata block and reach it in one call.

## The 500-tolerance — please read

Ghostfolio's `POST /api/v1/admin/profile-data/{source}/{symbol}` returns **HTTP 500 on both duplicate-create AND some first-time-create paths** (observed against Ghostfolio v3.2.0), while still persisting the record. This is upstream Ghostfolio behaviour, not something this tool can clean up.

To handle that, the implementation tolerates 500 on the POST step and relies on the subsequent PATCH as the source of truth: if the profile doesn't actually exist after the POST, the PATCH will surface a 404 loudly. The docstring and an inline comment both explain this explicitly so it doesn't look mysterious.

If you'd prefer a different shape — e.g. a GET-first existence check, or splitting into separate `create_asset_profile` / `update_asset_profile` tools — happy to rework. I tried the GET-first pattern first and found it brittle against the same v3.2.0 quirk; the swallow-500 pattern is what's been reliable in practice.

## Behaviour

- POST `/api/v1/admin/profile-data/{data_source}/{symbol}` with empty body (tolerates 500)
- PATCH `/api/v1/admin/profile-data/{data_source}/{symbol}` with metadata
- Returns the PATCH response (final profile state)

## Annotations

- `readOnlyHint`: false
- `destructiveHint`: false (creates or updates; doesn't delete)
- `idempotentHint`: true (same input → same end state)

## Compatibility

Ghostfolio rejects admin/profile-data writes against auto-fetched data sources, so the tool is effectively MANUAL-only at runtime. Documented in the parameter description.

## Style

Matches existing tool style; README updated with one bullet under "Market Data & Symbol Tools" calling out the idempotency behaviour.