### PR TITLE
feat(tools): add delete_asset_profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Sentry is completely optional. If you don't set `SENTRY_DSN`, the server will ru
 - `lookup_symbols`: Search for symbols using a query string
 - `get_asset_profile`: Get asset profile information for a specific symbol
 - `upsert_asset_profile`: Create-or-update an asset profile (idempotent; tolerates Ghostfolio's HTTP 500 on the create step and relies on the subsequent PATCH as the source of truth)
+- `delete_asset_profile`: Delete an asset profile (destructive operation; may delete associated activities and market data depending on backend rules)
 
 ### Data Import Tools
 

--- a/src/ghostfolio_mcp/ghostfolio_tools.py
+++ b/src/ghostfolio_mcp/ghostfolio_tools.py
@@ -308,6 +308,43 @@ def register_tools(mcp: FastMCP, config: GhostfolioConfig) -> None:
                 f"admin/profile-data/{data_source}/{symbol}", data=patch_payload
             )
 
+    @mcp.tool(
+        tags={"asset", "profile", "delete"},
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+        },
+    )
+    async def delete_asset_profile(
+        data_source: Annotated[
+            str,
+            Field(
+                description="Data source for the symbol. Typically 'MANUAL' — Ghostfolio rejects profile-data deletes for auto-fetched sources"
+            ),
+        ],
+        symbol: Annotated[
+            str,
+            Field(description="Symbol/ticker of the asset to delete"),
+        ],
+    ) -> dict[str, Any]:
+        """
+        Delete an asset profile.
+
+        Removes the profile-data record for the given data source and symbol.
+        Be careful, this might delete associated activities and market data
+        depending on backend rules!
+
+        Args:
+            data_source: Data source (typically 'MANUAL')
+            symbol: Symbol/ticker of the asset to delete
+
+        Returns:
+            Dictionary containing the deletion status
+        """
+        async with get_ghostfolio_client(config) as client:
+            return await client.delete(f"admin/profile-data/{data_source}/{symbol}")
+
     # =============================================================================
     # IMPORT ENDPOINTS
     # =============================================================================


### PR DESCRIPTION
## Summary

Mirrors the existing `delete_account` / `delete_activity` shape: DELETEs `admin/profile-data/{data_source}/{symbol}`. Closes the lifecycle for asset profiles so an MCP client can fully manage manually-tracked assets without dropping into the admin UI.

## Motivation

Without a delete tool, agent-created profiles accumulate over time (test entries, closed pension contracts, retired positions) and the only way to remove them is the admin UI. PR #30 (`add_market_data_points`) and PR #31 (`upsert_asset_profile`) cover create/update; this PR completes the CRUD set.

## Behaviour

- DELETE `/api/v1/admin/profile-data/{data_source}/{symbol}`
- Returns Ghostfolio's deletion response

## Annotations

- `readOnlyHint`: false
- `destructiveHint`: **true**
- `idempotentHint`: false

The docstring carries the same caveat as `delete_account`: deletion may cascade to associated activities and market data depending on backend rules.

## Compatibility

Ghostfolio rejects admin/profile-data deletes against auto-fetched data sources; effectively MANUAL-only at runtime.

## Style

Matches existing destructive tool style (`delete_account`, `delete_activity`). README updated with one bullet under "Market Data & Symbol Tools".