### PR TITLE
fix(docker): scope healthcheck to http transport mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ HEALTHCHECK \
   --timeout=5s \
   --start-period=5s \
   --retries=3 \
-  CMD nc -z 127.0.0.1 8000 || exit 1
+  CMD if [ "$MCP_TRANSPORT" = "http" ]; then nc -z 127.0.0.1 "${MCP_HTTP_PORT:-8000}" || exit 1; fi
 
 ENV MCP_TRANSPORT=http
 ENV MCP_HTTP_HOST=0.0.0.0


### PR DESCRIPTION
## Summary

The Dockerfile sets `MCP_TRANSPORT=http` and `EXPOSE 8000` as defaults, but the same image is commonly run with `MCP_TRANSPORT=stdio` (e.g. when the container is spawned by an MCP host over stdio). In stdio mode no HTTP server listens on port 8000, so the existing `nc -z 127.0.0.1 8000` healthcheck always fails and `docker ps` reports the container as `unhealthy` forever despite the MCP server working correctly.

This patch makes the healthcheck transport-aware: it runs the port probe only when `MCP_TRANSPORT=http`, and short-circuits to success otherwise. Same probe behaviour for the HTTP default; clean health status for stdio runs.

## Behaviour matrix

| `MCP_TRANSPORT` | Behaviour |
|---|---|
| unset / `http` (default) | `nc -z 127.0.0.1 ${MCP_HTTP_PORT:-8000}` — same as before |
| `stdio` | shell exits 0 — container reports healthy |
| anything else | shell exits 0 — container reports healthy (matches "no HTTP server" assumption) |

`${MCP_HTTP_PORT:-8000}` honours the existing `MCP_HTTP_PORT` env var if the user has overridden the default port.

## Why this matters

Operators running the image via stdio (which is the typical MCP-host pattern) currently have to override or disable the healthcheck themselves to get a clean `docker ps`. With this change, the image works correctly out of the box for both transports.

## Verification

Tested locally with `MCP_TRANSPORT=stdio` — container reports `healthy` instead of `unhealthy`. HTTP-mode behaviour unchanged.