### PR TITLE
fix(tools): get_orders hits renamed activities endpoint

### DIFF
--- a/src/ghostfolio_mcp/ghostfolio_tools.py
+++ b/src/ghostfolio_mcp/ghostfolio_tools.py
@@ -505,7 +505,7 @@ def register_tools(mcp: FastMCP, config: GhostfolioConfig) -> None:
         """
         async with get_ghostfolio_client(config) as client:
             params = {"accounts": account_id} if account_id else None
-            return await client.get("order", params=params)
+            return await client.get("activities", params=params)
 
     @mcp.tool(
         tags={"portfolio", "activities", "create"},


### PR DESCRIPTION
 ## Summary
 
 `get_orders` always returns **HTTP 404**. Ghostfolio renamed its
 `OrderController` to `ActivitiesController` (`@Controller('activities')` in
 `apps/api/src/app/activities/activities.controller.ts`), so `GET /api/v1/order`
 no longer exists on current Ghostfolio. Every `get_orders` call — with or
 without an `account_id` filter — hits the dead route and 404s.
 
 ## Fix
 
 Point `get_orders` at the renamed endpoint:
 
 ```diff
 -            return await client.get("order", params=params)
 +            return await client.get("activities", params=params)
  ```

The new route is a drop-in replacement:

 - Same query param — @Query('accounts') (the tool already passes {"accounts": account_id}).
 - Same response shape — { activities, count }.

Verification

Tested against a live Ghostfolio instance via SSE transport. Before: get_orders
404'd on /api/v1/order. After: client.get("activities") resolves to
/api/v1/activities/ and returns the full activities payload (verified both
unfiltered and with an account_id filter).