### PR TITLE
feat(auth): add optional OIDC/OAuth authentication for HTTP transports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,3 +56,24 @@ MCP_TRANSPORT=stdio
 # MCP_HTTP_PORT=8000
 # Optional bearer token for authentication (leave empty for no auth)
 # MCP_HTTP_BEARER_TOKEN=
+
+# OIDC / OAuth Authentication (used when MCP_TRANSPORT=sse or MCP_TRANSPORT=http)
+# Set all four to expose an OAuth interface brokered to an upstream identity provider
+# Takes precedence over MCP_HTTP_BEARER_TOKEN; leave unset to disable
+# Discovery document URL of the identity provider
+# OIDC_CONFIG_URL=https://id.example.com/.well-known/openid-configuration
+# Client credentials registered with the identity provider
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# Public base URL of this server (must be HTTPS), used to build its OAuth endpoints
+# OIDC_BASE_URL=https://ghostfolio-mcp.example.com
+# Callback path registered on the identity provider (default: /auth/callback)
+# OIDC_REDIRECT_PATH=/auth/callback
+# Comma-separated scopes required on presented tokens (empty for none)
+# OIDC_REQUIRED_SCOPES=
+# Comma-separated allowed client redirect URI patterns, wildcards accepted
+# OIDC_ALLOWED_REDIRECT_URIS=
+# Verify the id_token instead of the access token, for opaque access tokens
+# OIDC_VERIFY_ID_TOKEN=false
+# Forward the RFC 8707 'resource' indicator upstream (rejected by some providers)
+# OIDC_FORWARD_RESOURCE=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,9 @@ ENV PYTHONUNBUFFERED=1
 
 RUN apk add --no-cache ca-certificates \
     && addgroup -g 1000 appuser \
-    && adduser -D -u 1000 -G appuser appuser
+    && adduser -D -u 1000 -G appuser appuser \
+    && mkdir -p /data \
+    && chown appuser:appuser /data
 
 COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 
@@ -39,6 +41,9 @@ WORKDIR /app
 USER appuser
 
 ENV PATH="/app/.venv/bin:$PATH"
+
+# OAuth state for OIDC; mount a volume on /data to persist it
+ENV FASTMCP_HOME=/data
 
 HEALTHCHECK \
   --interval=15s \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Ghostfolio MCP Server is a Python-based Model Context Protocol (MCP) server desi
 - SSL/TLS support and configurable timeouts
 - Extensible with custom middlewares and tag-based tool filtering
 - Optional tool-search transform for large tool catalogs
+- Bearer token or OIDC/OAuth authentication for HTTP transports
 
 ## Installation
 
@@ -189,6 +190,19 @@ MCP_TRANSPORT=stdio
 # MCP_HTTP_PORT=8000
 # Optional bearer token for authentication (leave empty for no auth)
 # MCP_HTTP_BEARER_TOKEN=
+
+# OIDC / OAuth Authentication (optional, for remote hosting)
+# Set all four to enable; takes precedence over MCP_HTTP_BEARER_TOKEN
+# OIDC_CONFIG_URL=https://id.example.com/.well-known/openid-configuration
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_BASE_URL=https://ghostfolio-mcp.example.com
+# Optional OIDC settings
+# OIDC_REDIRECT_PATH=/auth/callback
+# OIDC_REQUIRED_SCOPES=
+# OIDC_ALLOWED_REDIRECT_URIS=
+# OIDC_VERIFY_ID_TOKEN=false
+# OIDC_FORWARD_RESOURCE=false
 ```
 
 ### Sentry Error Tracking & Monitoring (Optional)
@@ -455,6 +469,71 @@ curl -H "Authorization: Bearer your-secret-token" \
 
 **Note**: The HTTP transport requires proper JSON-RPC formatting with `jsonrpc` and `id` fields. The server may also require session initialization for some operations.
 
+### OIDC / OAuth Authentication (Optional)
+
+A static bearer token is enough for machine-to-machine clients, but many MCP clients can only authenticate over OAuth with Dynamic Client Registration. For those, the server can act as an OAuth interface in front of an existing OIDC identity provider (Authentik, Keycloak, PocketID, Auth0, Entra ID, ...) using FastMCP's `OIDCProxy`. Clients register and authenticate against this server; the server brokers the flow upstream. No Ghostfolio credential ever reaches the client.
+
+This applies to the `sse` and `http` transports only.
+
+#### Registering the client
+
+Create a **confidential** client (client ID + secret) on your identity provider with the redirect URI set to `OIDC_BASE_URL` + `OIDC_REDIRECT_PATH`, for example `https://ghostfolio-mcp.example.com/auth/callback`.
+
+#### Configuration
+
+```env
+MCP_TRANSPORT=http
+MCP_HTTP_HOST=0.0.0.0
+MCP_HTTP_PORT=8000
+
+# All four are required to enable OIDC
+OIDC_CONFIG_URL=https://id.example.com/.well-known/openid-configuration
+OIDC_CLIENT_ID=your-client-id
+OIDC_CLIENT_SECRET=your-client-secret
+# Public URL where this server is reachable, used to build its OAuth endpoints.
+# Must be HTTPS (except on localhost), as required for an OAuth issuer.
+OIDC_BASE_URL=https://ghostfolio-mcp.example.com
+```
+
+OIDC is entirely optional. Leaving these unset keeps the existing behaviour, and a partially configured setup is ignored with a warning rather than half-enabled. When OIDC is configured it takes precedence over `MCP_HTTP_BEARER_TOKEN`.
+
+Optional settings:
+
+```env
+# Callback path registered on the identity provider (default: /auth/callback)
+OIDC_REDIRECT_PATH=/auth/callback
+
+# Comma-separated scopes required on presented tokens
+OIDC_REQUIRED_SCOPES=openid,profile
+
+# Comma-separated allowed client redirect URI patterns (wildcards accepted)
+OIDC_ALLOWED_REDIRECT_URIS=https://example.com/*
+
+# Verify the id_token instead of the access token (default: false)
+OIDC_VERIFY_ID_TOKEN=false
+
+# Forward the RFC 8707 'resource' indicator upstream (default: false)
+OIDC_FORWARD_RESOURCE=false
+```
+
+`OIDC_ALLOWED_REDIRECT_URIS` restricts which clients may complete the flow. Leaving it unset accepts any redirect URI a client registers, so set it to the hosts you expect, for example `https://example.com/*`.
+
+Set `OIDC_VERIFY_ID_TOKEN=true` if your identity provider issues opaque (non-JWT) access tokens; the `id_token` is then verified instead.
+
+`OIDC_FORWARD_RESOURCE` is off by default because identity providers that do not implement RFC 8707 resource indicators reject the authorization request with `invalid_request`, which breaks login immediately after consent. Turn it on only if your provider supports resource indicators. Token audience binding is unaffected either way.
+
+#### Persisting OAuth state
+
+Client registrations and encrypted tokens are stored on disk, under FastMCP's data directory. If that directory is not persistent, every restart forces all clients to register and authenticate again. The Docker image sets `FASTMCP_HOME=/data`, so mount a volume there:
+
+```sh
+docker run -v ghostfolio-mcp-data:/data --env-file .env ghcr.io/mhajder/ghostfolio-mcp:latest
+```
+
+#### Running behind a reverse proxy
+
+`OIDC_BASE_URL` must be the externally reachable HTTPS URL, and the proxy must forward the `Host` header unchanged, otherwise the OAuth metadata this server advertises will point at the wrong host.
+
 ## Data Sources
 
 Ghostfolio supports multiple data sources for market data and symbols:
@@ -477,6 +556,8 @@ docker pull ghcr.io/mhajder/ghostfolio-mcp:latest
 # MCPO image for usage with Open WebUI
 docker pull ghcr.io/mhajder/ghostfolio-mcpo:latest
 ```
+
+When [OIDC authentication](#oidc--oauth-authentication-optional) is enabled, mount a volume on `/data` so OAuth client registrations survive container recreation.
 
 ## Contributing
 

--- a/src/ghostfolio_mcp/auth.py
+++ b/src/ghostfolio_mcp/auth.py
@@ -1,0 +1,70 @@
+"""Authentication provider selection for the MCP server.
+
+Kept separate from server.py so the decision here is a pure function of the
+transport config and can be tested without importing the server module.
+"""
+
+import logging
+from typing import Any
+
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+from ghostfolio_mcp.models import TransportConfig
+
+logger = logging.getLogger(__name__)
+
+
+def build_auth_provider(config: TransportConfig) -> Any | None:
+    """Build the auth provider for the configured transport.
+
+    Precedence: OIDC > static bearer token > no authentication.
+
+    OIDC exposes a Dynamic Client Registration compliant OAuth interface
+    brokered to an upstream identity provider, which is what MCP clients that
+    only speak OAuth (for example remote connectors) require. The static bearer
+    token is kept for machine-to-machine clients.
+
+    OIDC is entirely optional: leaving its settings unset simply falls through
+    to the existing behaviour.
+    """
+    missing = config.missing_oidc_settings()
+    if missing:
+        logger.warning(
+            "OIDC is only partially configured (missing %s) and has been ignored. "
+            "Set all of OIDC_CONFIG_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET and "
+            "OIDC_BASE_URL to enable it.",
+            ", ".join(missing),
+        )
+
+    credentials = config.oidc_credentials()
+    if credentials is not None:
+        config_url, client_id, client_secret, base_url = credentials
+
+        # Imported lazily: constructing the provider performs OIDC discovery, and
+        # STDIO users should not pay for the import at all.
+        from fastmcp.server.auth.oidc_proxy import OIDCProxy
+
+        logger.info("OIDC authentication enabled (upstream: %s)", config_url)
+        return OIDCProxy(
+            config_url=config_url,
+            client_id=client_id,
+            client_secret=client_secret,
+            base_url=base_url,
+            redirect_path=config.oidc_redirect_path,
+            required_scopes=config.oidc_required_scopes,
+            allowed_client_redirect_uris=config.oidc_allowed_redirect_uris,
+            verify_id_token=config.oidc_verify_id_token,
+            forward_resource=config.oidc_forward_resource,
+        )
+
+    if config.http_bearer_token:
+        return StaticTokenVerifier(
+            tokens={
+                config.http_bearer_token: {
+                    "client_id": "authenticated-client",
+                    "scopes": ["read", "write"],
+                }
+            }
+        )
+
+    return None

--- a/src/ghostfolio_mcp/ghostfolio_client.py
+++ b/src/ghostfolio_mcp/ghostfolio_client.py
@@ -227,11 +227,38 @@ def get_transport_config_from_env() -> TransportConfig:
     if http_bearer_token is not None:
         http_bearer_token = http_bearer_token.strip() or None
 
+    def _clean(name: str) -> str | None:
+        """Read an env var, treating a blank value as unset."""
+        value = os.getenv(name)
+        if value is None:
+            return None
+        return value.strip() or None
+
+    def _csv(name: str) -> list[str] | None:
+        """Read a comma-separated env var, treating a blank value as unset."""
+        raw = _clean(name)
+        if raw is None:
+            return None
+        return [item.strip() for item in raw.split(",") if item.strip()] or None
+
     return TransportConfig(
         transport_type=os.getenv("MCP_TRANSPORT", "stdio").lower(),
         http_host=os.getenv("MCP_HTTP_HOST", "127.0.0.1"),
         http_port=int(os.getenv("MCP_HTTP_PORT", "8000")),
         http_bearer_token=http_bearer_token,
+        oidc_config_url=_clean("OIDC_CONFIG_URL"),
+        oidc_client_id=_clean("OIDC_CLIENT_ID"),
+        oidc_client_secret=_clean("OIDC_CLIENT_SECRET"),
+        oidc_base_url=_clean("OIDC_BASE_URL"),
+        oidc_redirect_path=_clean("OIDC_REDIRECT_PATH") or "/auth/callback",
+        oidc_required_scopes=_csv("OIDC_REQUIRED_SCOPES"),
+        oidc_allowed_redirect_uris=_csv("OIDC_ALLOWED_REDIRECT_URIS"),
+        oidc_verify_id_token=parse_bool(
+            os.getenv("OIDC_VERIFY_ID_TOKEN"), default=False
+        ),
+        oidc_forward_resource=parse_bool(
+            os.getenv("OIDC_FORWARD_RESOURCE"), default=False
+        ),
     )
 
 

--- a/src/ghostfolio_mcp/models.py
+++ b/src/ghostfolio_mcp/models.py
@@ -53,3 +53,88 @@ class TransportConfig(BaseModel):
     http_bearer_token: str | None = Field(
         None, description="Bearer token for HTTP authentication"
     )
+    # OIDC / OAuth. When config_url, client_id, client_secret and base_url are all
+    # set, the server exposes an OAuth interface with Dynamic Client Registration
+    # (FastMCP's OIDCProxy) brokered to an upstream identity provider, so MCP clients
+    # that can only authenticate over OAuth are able to connect.
+    oidc_config_url: str | None = Field(
+        None,
+        description="Upstream OIDC discovery URL (.../.well-known/openid-configuration)",
+    )
+    oidc_client_id: str | None = Field(
+        None, description="Client ID registered with the upstream identity provider"
+    )
+    oidc_client_secret: str | None = Field(
+        None, description="Client secret registered with the upstream identity provider"
+    )
+    oidc_base_url: str | None = Field(
+        None,
+        description="Public base URL where this server's OAuth endpoints are reachable",
+    )
+    oidc_redirect_path: str = Field(
+        "/auth/callback",
+        description="Callback path registered on the upstream identity provider",
+    )
+    oidc_required_scopes: list[str] | None = Field(
+        None, description="Scopes required on presented tokens (None = do not enforce)"
+    )
+    oidc_allowed_redirect_uris: list[str] | None = Field(
+        None,
+        description=(
+            "Allowed MCP client redirect URI patterns (wildcards accepted). "
+            "None = OIDCProxy default (registered URIs plus loopback variance)"
+        ),
+    )
+    oidc_verify_id_token: bool = Field(
+        False,
+        description=(
+            "Verify the id_token instead of the access_token, for identity providers "
+            "that issue opaque (non-JWT) access tokens"
+        ),
+    )
+    oidc_forward_resource: bool = Field(
+        False,
+        description=(
+            "Forward the RFC 8707 'resource' indicator to the upstream identity "
+            "provider. Off by default because providers that do not implement "
+            "resource indicators reject the authorization request with "
+            "invalid_request. Token audience binding is unaffected."
+        ),
+    )
+
+    def missing_oidc_settings(self) -> list[str]:
+        """Names of OIDC settings that are needed but absent.
+
+        Empty when OIDC is fully configured and when it is not configured at all;
+        non-empty only for a half-configured setup, which is worth a warning
+        because the server then falls back to whatever else is configured.
+        """
+        provided = {
+            "OIDC_CONFIG_URL": self.oidc_config_url,
+            "OIDC_CLIENT_ID": self.oidc_client_id,
+            "OIDC_CLIENT_SECRET": self.oidc_client_secret,
+            "OIDC_BASE_URL": self.oidc_base_url,
+        }
+        missing = [name for name, value in provided.items() if not value]
+        return [] if len(missing) == len(provided) else missing
+
+    def oidc_credentials(self) -> tuple[str, str, str, str] | None:
+        """Return the four required OIDC settings, or None when OIDC is off."""
+        if not (
+            self.oidc_config_url
+            and self.oidc_client_id
+            and self.oidc_client_secret
+            and self.oidc_base_url
+        ):
+            return None
+        return (
+            self.oidc_config_url,
+            self.oidc_client_id,
+            self.oidc_client_secret,
+            self.oidc_base_url,
+        )
+
+    @property
+    def oidc_enabled(self) -> bool:
+        """OIDC is active only when every upstream credential is present."""
+        return self.oidc_credentials() is not None

--- a/src/ghostfolio_mcp/server.py
+++ b/src/ghostfolio_mcp/server.py
@@ -13,11 +13,11 @@ from importlib.metadata import version
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 from fastmcp import settings
-from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
 from fastmcp.server.middleware.rate_limiting import SlidingWindowRateLimitingMiddleware
 from fastmcp.server.transforms.search import BM25SearchTransform
 from fastmcp.server.transforms.search import RegexSearchTransform
 
+from ghostfolio_mcp.auth import build_auth_provider
 from ghostfolio_mcp.ghostfolio_client import get_ghostfolio_config_from_env
 from ghostfolio_mcp.ghostfolio_client import get_transport_config_from_env
 from ghostfolio_mcp.sentry_init import init_sentry
@@ -63,19 +63,7 @@ except Exception as e:
     logger.error(f"Invalid configuration: {e}")
     raise
 
-# Create auth provider if bearer token is configured
-auth_provider = None
-if getattr(TRANSPORT_CONFIG, "http_bearer_token", None):
-    bearer_token = TRANSPORT_CONFIG.http_bearer_token
-    if bearer_token:  # Type narrowing: ensures bearer_token is str, not None
-        auth_provider = StaticTokenVerifier(
-            tokens={
-                bearer_token: {
-                    "client_id": "authenticated-client",
-                    "scopes": ["read", "write"],
-                }
-            }
-        )
+auth_provider = build_auth_provider(TRANSPORT_CONFIG)
 
 # Initialize FastMCP server
 mcp = FastMCP(
@@ -167,6 +155,7 @@ def main():
     if (
         TRANSPORT_CONFIG.transport_type in {"sse", "http"}
         and not TRANSPORT_CONFIG.http_bearer_token
+        and not TRANSPORT_CONFIG.oidc_enabled
     ):
         logger.warning(
             "WARNING: MCP_HTTP_BEARER_TOKEN is not set. The MCP server will run WITHOUT authentication. "
@@ -182,7 +171,9 @@ def main():
         logger.info(
             f"Using HTTP SSE transport on {TRANSPORT_CONFIG.http_host}:{TRANSPORT_CONFIG.http_port}"
         )
-        if TRANSPORT_CONFIG.http_bearer_token:
+        if TRANSPORT_CONFIG.oidc_enabled:
+            logger.info("OIDC authentication enabled for SSE transport")
+        elif TRANSPORT_CONFIG.http_bearer_token:
             logger.info("Bearer token authentication enabled for SSE transport")
 
         # Run with HTTP SSE transport
@@ -195,7 +186,9 @@ def main():
         logger.info(
             f"Using HTTP Streamable transport on {TRANSPORT_CONFIG.http_host}:{TRANSPORT_CONFIG.http_port}"
         )
-        if TRANSPORT_CONFIG.http_bearer_token:
+        if TRANSPORT_CONFIG.oidc_enabled:
+            logger.info("OIDC authentication enabled for Streamable transport")
+        elif TRANSPORT_CONFIG.http_bearer_token:
             logger.info("Bearer token authentication enabled for Streamable transport")
 
         # Run with HTTP Streamable transport

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,110 @@
+import pytest
+from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+from ghostfolio_mcp.auth import build_auth_provider
+from ghostfolio_mcp.models import TransportConfig
+
+OIDC_SETTINGS = {
+    "oidc_config_url": "https://id.example.com/.well-known/openid-configuration",
+    "oidc_client_id": "client-id",
+    "oidc_client_secret": "client-secret",
+    "oidc_base_url": "https://mcp.example.com",
+}
+
+
+# Stand-in for OIDCProxy, which performs OIDC discovery when constructed.
+class FakeOIDCProxy:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+# Patches the OIDCProxy that build_auth_provider imports lazily.
+@pytest.fixture
+def fake_oidc_proxy(monkeypatch):
+    monkeypatch.setattr(
+        "fastmcp.server.auth.oidc_proxy.OIDCProxy", FakeOIDCProxy, raising=True
+    )
+    return FakeOIDCProxy
+
+
+def test_build_auth_provider_returns_none_without_auth():
+    assert build_auth_provider(TransportConfig()) is None
+
+
+# OIDC is optional, so an unconfigured server must not be warned at.
+def test_build_auth_provider_is_quiet_when_oidc_is_unconfigured(caplog):
+    with caplog.at_level("WARNING"):
+        provider = build_auth_provider(TransportConfig())
+
+    assert provider is None
+    assert caplog.records == []
+
+
+def test_partial_oidc_config_warns_once_and_falls_back(caplog):
+    config = TransportConfig(
+        http_bearer_token="secret-token",
+        oidc_config_url="https://id.example.com",
+        oidc_client_id="client-id",
+    )
+
+    with caplog.at_level("WARNING"):
+        provider = build_auth_provider(config)
+
+    assert isinstance(provider, StaticTokenVerifier)
+    assert len(caplog.records) == 1
+    assert "OIDC_CLIENT_SECRET, OIDC_BASE_URL" in caplog.records[0].message
+
+
+def test_build_auth_provider_uses_bearer_token():
+    provider = build_auth_provider(TransportConfig(http_bearer_token="secret-token"))
+
+    assert isinstance(provider, StaticTokenVerifier)
+
+
+@pytest.mark.usefixtures("fake_oidc_proxy")
+def test_build_auth_provider_prefers_oidc_over_bearer_token():
+    config = TransportConfig(http_bearer_token="secret-token", **OIDC_SETTINGS)
+
+    provider = build_auth_provider(config)
+
+    assert isinstance(provider, FakeOIDCProxy)
+
+
+@pytest.mark.usefixtures("fake_oidc_proxy")
+def test_build_auth_provider_passes_oidc_settings_through():
+    config = TransportConfig(
+        **OIDC_SETTINGS,
+        oidc_redirect_path="/oauth/callback",
+        oidc_required_scopes=["openid", "profile"],
+        oidc_allowed_redirect_uris=["https://example.com/*"],
+        oidc_verify_id_token=True,
+        oidc_forward_resource=True,
+    )
+
+    provider = build_auth_provider(config)
+
+    assert isinstance(provider, FakeOIDCProxy)
+    assert provider.kwargs == {
+        "config_url": OIDC_SETTINGS["oidc_config_url"],
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+        "base_url": "https://mcp.example.com",
+        "redirect_path": "/oauth/callback",
+        "required_scopes": ["openid", "profile"],
+        "allowed_client_redirect_uris": ["https://example.com/*"],
+        "verify_id_token": True,
+        "forward_resource": True,
+    }
+
+
+@pytest.mark.usefixtures("fake_oidc_proxy")
+# The defaults that differ from FastMCP's own must not drift silently.
+def test_oidc_defaults_are_conservative():
+    provider = build_auth_provider(TransportConfig(**OIDC_SETTINGS))
+
+    assert isinstance(provider, FakeOIDCProxy)
+    # FastMCP defaults forward_resource to True, which identity providers without
+    # RFC 8707 support reject with invalid_request.
+    assert provider.kwargs["forward_resource"] is False
+    assert provider.kwargs["verify_id_token"] is False
+    assert provider.kwargs["redirect_path"] == "/auth/callback"

--- a/tests/test_transport_config.py
+++ b/tests/test_transport_config.py
@@ -1,0 +1,158 @@
+import pytest
+
+from ghostfolio_mcp.ghostfolio_client import get_transport_config_from_env
+from ghostfolio_mcp.models import TransportConfig
+
+OIDC_ENV = {
+    "OIDC_CONFIG_URL": "https://id.example.com/.well-known/openid-configuration",
+    "OIDC_CLIENT_ID": "client-id",
+    "OIDC_CLIENT_SECRET": "client-secret",
+    "OIDC_BASE_URL": "https://mcp.example.com",
+}
+
+TRANSPORT_ENV_VARS = (
+    "MCP_TRANSPORT",
+    "MCP_HTTP_HOST",
+    "MCP_HTTP_PORT",
+    "MCP_HTTP_BEARER_TOKEN",
+    "OIDC_CONFIG_URL",
+    "OIDC_CLIENT_ID",
+    "OIDC_CLIENT_SECRET",
+    "OIDC_BASE_URL",
+    "OIDC_REDIRECT_PATH",
+    "OIDC_REQUIRED_SCOPES",
+    "OIDC_ALLOWED_REDIRECT_URIS",
+    "OIDC_VERIFY_ID_TOKEN",
+    "OIDC_FORWARD_RESOURCE",
+)
+
+
+# Isolates each test from the ambient environment and any local .env file.
+@pytest.fixture(autouse=True)
+def _clean_transport_env(monkeypatch):
+    for name in TRANSPORT_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_defaults_disable_oidc_and_leave_guard_unset():
+    config = get_transport_config_from_env()
+
+    assert config.oidc_enabled is False
+    assert config.oidc_redirect_path == "/auth/callback"
+    assert config.oidc_forward_resource is False
+    assert config.oidc_verify_id_token is False
+
+
+def test_full_oidc_environment_enables_oidc(monkeypatch):
+    for name, value in OIDC_ENV.items():
+        monkeypatch.setenv(name, value)
+
+    config = get_transport_config_from_env()
+
+    assert config.oidc_enabled is True
+    assert config.oidc_config_url == OIDC_ENV["OIDC_CONFIG_URL"]
+    assert config.oidc_base_url == "https://mcp.example.com"
+
+
+# A half-configured setup must not block startup, only stay disabled.
+def test_partial_oidc_environment_does_not_enable_oidc(monkeypatch):
+    monkeypatch.setenv("OIDC_CONFIG_URL", OIDC_ENV["OIDC_CONFIG_URL"])
+    monkeypatch.setenv("OIDC_CLIENT_ID", "client-id")
+
+    config = get_transport_config_from_env()
+
+    assert config.oidc_enabled is False
+    assert config.missing_oidc_settings() == ["OIDC_CLIENT_SECRET", "OIDC_BASE_URL"]
+
+
+def test_blank_oidc_values_count_as_unset(monkeypatch):
+    for name in OIDC_ENV:
+        monkeypatch.setenv(name, "   ")
+
+    config = get_transport_config_from_env()
+
+    assert config.oidc_enabled is False
+    assert config.oidc_config_url is None
+
+
+# A declared-but-empty value must not become an empty redirect path.
+@pytest.mark.parametrize("value", ["", "   "])
+def test_blank_redirect_path_falls_back_to_the_default(monkeypatch, value):
+    monkeypatch.setenv("OIDC_REDIRECT_PATH", value)
+
+    assert get_transport_config_from_env().oidc_redirect_path == "/auth/callback"
+
+
+def test_redirect_path_is_read_and_stripped(monkeypatch):
+    monkeypatch.setenv("OIDC_REDIRECT_PATH", "  /oauth/callback  ")
+
+    assert get_transport_config_from_env().oidc_redirect_path == "/oauth/callback"
+
+
+def test_comma_separated_values_are_split_and_stripped(monkeypatch):
+    monkeypatch.setenv("OIDC_REQUIRED_SCOPES", " openid , profile ")
+    monkeypatch.setenv("OIDC_ALLOWED_REDIRECT_URIS", "https://example.com/*")
+
+    config = get_transport_config_from_env()
+
+    assert config.oidc_required_scopes == ["openid", "profile"]
+    assert config.oidc_allowed_redirect_uris == ["https://example.com/*"]
+
+
+@pytest.mark.parametrize("value", ["", "  ", ",", " , "])
+def test_blank_comma_separated_values_are_unset(monkeypatch, value):
+    monkeypatch.setenv("OIDC_REQUIRED_SCOPES", value)
+
+    assert get_transport_config_from_env().oidc_required_scopes is None
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        {},
+        {
+            "oidc_config_url": "https://id.example.com",
+            "oidc_client_id": "client-id",
+            "oidc_client_secret": "client-secret",
+            "oidc_base_url": "https://mcp.example.com",
+        },
+    ],
+)
+def test_oidc_enabled_requires_every_setting(settings):
+    assert TransportConfig(**settings).oidc_enabled is bool(settings)
+
+
+@pytest.mark.parametrize(
+    "omitted",
+    ["oidc_config_url", "oidc_client_id", "oidc_client_secret", "oidc_base_url"],
+)
+def test_missing_oidc_settings_reports_each_absent_field(omitted):
+    settings = {
+        "oidc_config_url": "https://id.example.com",
+        "oidc_client_id": "client-id",
+        "oidc_client_secret": "client-secret",
+        "oidc_base_url": "https://mcp.example.com",
+    }
+    del settings[omitted]
+
+    config = TransportConfig(**settings)
+
+    assert config.missing_oidc_settings() == [omitted.upper()]
+    assert config.oidc_enabled is False
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        {},
+        {
+            "oidc_config_url": "https://id.example.com",
+            "oidc_client_id": "client-id",
+            "oidc_client_secret": "client-secret",
+            "oidc_base_url": "https://mcp.example.com",
+        },
+    ],
+)
+# Nothing to report when OIDC is fully configured or not configured at all.
+def test_missing_oidc_settings_is_empty_when_all_or_nothing_is_set(settings):
+    assert TransportConfig(**settings).missing_oidc_settings() == []


### PR DESCRIPTION
## Optional OIDC/OAuth authentication for HTTP transports

Follow-up to the issue where you said you'd take a PR for this.

A static bearer token covers machine-to-machine clients, but many MCP clients can only authenticate over OAuth with Dynamic Client Registration. This adds an optional OIDC branch built on FastMCP's `OIDCProxy`: the server exposes an OAuth interface brokered to an existing identity provider (Authentik, Keycloak, PocketID, Auth0, Entra ID, ...), so no Ghostfolio credential ever reaches the client.

### Nothing changes if you don't use it

This was the main design goal, and it is verified rather than asserted:

- No new dependency floor. `fastmcp>=3.2.0,<4` is untouched — `OIDCProxy` already accepts every argument passed here as of 3.2.0.
- No new imports on the STDIO path. `OIDCProxy` is imported lazily, only when OIDC is actually configured.
- No new log output, and no changed log strings.
- No changed defaults anywhere.

I diffed the full server output of this branch against `main` at `LOG_LEVEL=DEBUG` across seven configurations — stdio, http+bearer, sse+bearer, http with no auth, read-only mode, rate-limiting + tool-search, and disabled tags — and the output is byte-identical in all of them. (The disabled-tags line differs only by `set` iteration order, which `main` does against itself between runs.) The tool surface (36 tools) and the constructed auth provider are identical too.

### Behaviour

- Enabled only when `OIDC_CONFIG_URL`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` and `OIDC_BASE_URL` are all set; it then takes precedence over `MCP_HTTP_BEARER_TOKEN`.
- A half-configured setup is ignored with a single warning rather than failing to start.
- `OIDC_BASE_URL` must be HTTPS (except on localhost), as required of an OAuth issuer.

### One default that deliberately differs from FastMCP's

`forward_resource` is off. FastMCP forwards the RFC 8707 `resource` indicator by default, and identity providers that do not implement resource indicators reject the authorization request with `invalid_request` — which breaks login immediately after consent (hit this with PocketID). `OIDC_FORWARD_RESOURCE=true` restores it; token audience binding is unaffected either way.

### Structure

Auth-provider construction moves into a new `auth.py` as a pure function of `TransportConfig`. That keeps it unit-testable without importing `server.py`, which calls `load_dotenv()` and registers every tool at import time. Net effect on `server.py` is fewer lines than before.

### Docker

The image sets `FASTMCP_HOME=/data` so `OIDCProxy`'s client registrations and encrypted tokens survive container recreation when a volume is mounted there. Without persistence every restart forces all clients to register and log in again.

This is inert for everyone else: fastmcp reads `settings.home` in exactly two places, the OAuth proxy store and the version-check cache, and the latter is already short-circuited by `check_for_updates = "off"` in `server.py`. I deliberately did not add a `VOLUME` directive, since it creates a fresh anonymous volume per `docker run` and so preserves nothing anyway; a named volume is documented in the README instead. Happy to drop the Dockerfile change entirely if you'd rather keep persistence purely a deployment concern.

### Tests

46 tests pass (`tests/test_auth.py` and `tests/test_transport_config.py` are new). They cover provider precedence, the pass-through of every OIDC setting, the conservative `forward_resource` default, silent fallback when OIDC is absent, the single warning on partial config, and env parsing including blank-as-unset (a declared-but-empty `OIDC_REDIRECT_PATH` falls back to the default rather than becoming an empty path, matching the treatment of blank env vars elsewhere). `OIDCProxy` is stubbed, since constructing it performs OIDC discovery.

Verified end to end against a stub identity provider as well: the provider is built from a real discovery document and the OAuth metadata is advertised correctly at the public host.

### Not included

`server.json` is left alone — it doesn't list `MCP_HTTP_BEARER_TOKEN` either, so HTTP auth variables look intentionally out of scope there. Happy to add an `OIDC_*` block if you'd prefer.
